### PR TITLE
Print failures

### DIFF
--- a/exercise_28.rb
+++ b/exercise_28.rb
@@ -9,7 +9,26 @@
 
 # Driver Code: Do not edit under this line
 
-p sum_of_evens([25, 18, 3, 81, 5, 20, 12]) == 50 ? "Correct" : "Incorrect"
-p sum_of_evens([30, 4, 8, 11, 45, 76, 29]) ==  118 ? "Correct" : "Incorrect"
-p sum_of_evens([0, 1, 3, 5, 7, 9, 11, 13]) == 0 ? "Correct" : "Incorrect"
-p sum_of_evens([]) == 0 ? "Correct" : "Incorrect"
+# check_solution runs a single test case and prints whether it was
+# successful or not.
+def check_solution(test_number, array, expected)
+    actual = sum_of_evens(array)
+    if actual != expected
+        puts "Test ##{test_number}: Incorrect value: got #{actual}, expected #{expected}"
+        return false
+    end
+
+    puts "Test ##{test_number}: Correct"
+    return true
+end
+
+# run_tests runs each of the test cases.
+def run_tests()
+    check_solution(1, [25, 18, 3, 81, 5, 20, 12], 50)
+    check_solution(2, [30, 4, 8, 11, 45, 76, 29], 118)
+    check_solution(3, [0, 1, 3, 5, 7, 9, 11, 13], 0)
+    check_solution(4, [], 0)
+end
+
+# Execute the tests.
+run_tests()

--- a/exercise_29.rb
+++ b/exercise_29.rb
@@ -11,7 +11,26 @@
 
 # Driver Code: Do not edit under this line
 
-p is_coprime?(25, 12) == true ? "Correct" : "Incorrect"
-p is_coprime?(7, 11) == true ? "Correct" : "Incorrect"
-p is_coprime?(30, 9) == false ? "Correct" : "Incorrect"
-p is_coprime?(6, 24) == false ? "Correct" : "Incorrect"
+# check_solution runs a single test case and prints whether it was
+# successful or not.
+def check_solution(test_number, a, b, expected)
+    actual = is_coprime?(a, b)
+    if actual != expected
+        puts "Test ##{test_number}: Incorrect value: got #{actual}, expected #{expected}"
+        return false
+    end
+
+    puts "Test ##{test_number}: Correct"
+    return true
+end
+
+# run_tests runs each of the test cases.
+def run_tests()
+    check_solution(1, 25, 12, true)
+    check_solution(2, 7, 11, true)
+    check_solution(3, 30, 9, false)
+    check_solution(4, 6, 24, false)
+end
+
+# Execute the tests.
+run_tests()

--- a/exercise_30.rb
+++ b/exercise_30.rb
@@ -8,18 +8,36 @@
 
 
 # Driver Code: Do not edit under this line
-people_1 = [
-    {name: "Mars", age: 17},
-    {name: "Hector", age: 21},
-    {name: "Hera", age: 15},
-    {name: "Artemis", age: 16}
-]
-p adult_in_group?(people_1) == true ? "Correct" : "Incorrect"
 
-people_2 = [
-    {name: "Myles", age: 12},
-    {name: "Nona", age: 13},
-    {name: "Terminus", age: 10},
-    {name: "Erna", age: 16}
-]
-p adult_in_group?(people_2) == false ? "Correct" : "Incorrect"
+
+# check_solution runs a single test case and prints whether it was
+# successful or not.
+def check_solution(test_number, array, expected)
+    actual = adult_in_group?(array)
+    if actual != expected
+        puts "Test ##{test_number}: Incorrect value: got #{actual}, expected #{expected}"
+        return false
+    end
+
+    puts "Test ##{test_number}: Correct"
+    return true
+end
+
+# run_tests runs each of the test cases.
+def run_tests()
+    check_solution(1, [
+        {name: "Mars", age: 17},
+        {name: "Hector", age: 21},
+        {name: "Hera", age: 15},
+        {name: "Artemis", age: 16}
+    ], true)
+    check_solution(2, [
+        {name: "Myles", age: 12},
+        {name: "Nona", age: 13},
+        {name: "Terminus", age: 10},
+        {name: "Erna", age: 16}
+    ], false)
+end
+
+# Execute the tests.
+run_tests()

--- a/exercise_31.rb
+++ b/exercise_31.rb
@@ -9,7 +9,65 @@
 
 # Driver Code: Do not edit under this line
 
-p filter_lengths(["pear", "dragonfruit", "fig", "pineapple"], 4) == ["pear", "dragonfruit", "pineapple"] ? "Correct" : "Incorrect"
-p filter_lengths(["pear", "dragonfruit", "fig", "pineapple"]) == ["dragonfruit", "pineapple"] ? "Correct" : "Incorrect"
-p filter_lengths(["cat", "dog", "capybara", "mouse"], 7) == ["capybara"] ? "Correct" : "Incorrect"
-p filter_lengths(["cat", "dog", "capybara", "mouse"]) == ["capybara", "mouse"] ? "Correct" : "Incorrect"
+# check_solution_1 runs a single test case and prints whether it was
+# successful or not.
+def check_solution_1()
+    actual = filter_lengths(["pear", "dragonfruit", "fig", "pineapple"], 4)
+    expected = ["pear", "dragonfruit", "pineapple"]
+    if actual != expected
+        puts "Test #1: Incorrect value: got #{actual}, expected #{expected}"
+        return
+    end
+
+    puts "Test #1: Correct"
+end
+
+# check_solution_2 runs a single test case and prints whether it was
+# successful or not.
+def check_solution_2()
+    actual = filter_lengths(["pear", "dragonfruit", "fig", "pineapple"])
+    expected = ["dragonfruit", "pineapple"]
+    if actual != expected
+        puts "Test #2: Incorrect value: got #{actual}, expected #{expected}"
+        return
+    end
+
+    puts "Test #2: Correct"
+end
+
+# check_solution_3 runs a single test case and prints whether it was
+# successful or not.
+def check_solution_3()
+    actual = filter_lengths(["cat", "dog", "capybara", "mouse"], 7)
+    expected = ["capybara"]
+    if actual != expected
+        puts "Test #3: Incorrect value: got #{actual}, expected #{expected}"
+        return
+    end
+
+    puts "Test #3: Correct"
+end
+
+# check_solution_4 runs a single test case and prints whether it was
+# successful or not.
+def check_solution_4()
+    actual = filter_lengths(["cat", "dog", "capybara", "mouse"])
+    expected = ["capybara", "mouse"]
+    if actual != expected
+        puts "Test #4: Incorrect value: got #{actual}, expected #{expected}"
+        return
+    end
+
+    puts "Test #4: Correct"
+end
+
+# run_tests runs each of the test cases.
+def run_tests()
+    check_solution_1()
+    check_solution_2()
+    check_solution_3()
+    check_solution_4()
+end
+
+# Execute the tests.
+run_tests()

--- a/exercise_32.rb
+++ b/exercise_32.rb
@@ -9,6 +9,25 @@
 
 # Driver Code: Do not edit under this line
 
-p max_inject(1, -4, 0, 7, 5) == 7 ? "Correct" : "Incorrect"
-p max_inject(30, 28, 18) == 30 ? "Correct" : "Incorrect"
-p max_inject(-30, 28, 18) == 28 ? "Correct" : "Incorrect"
+# check_solution runs a single test case and prints whether it was
+# successful or not.
+def check_solution(test_number, expected, *values)
+    actual = max_inject(*values)
+    if actual != expected
+        puts "Test ##{test_number}: Incorrect value: got #{actual}, expected #{expected}"
+        return false
+    end
+
+    puts "Test ##{test_number}: Correct"
+    return true
+end
+
+# run_tests runs each of the test cases.
+def run_tests()
+    check_solution(1, 7, 1, -4, 0, 7, 5)
+    check_solution(2, 30, 30, 28, 18)
+    check_solution(3, 28, -30, 28, 18)
+end
+
+# Execute the tests.
+run_tests()

--- a/exercise_33.rb
+++ b/exercise_33.rb
@@ -14,20 +14,29 @@ end
 
 # Driver Code: Do not edit under this line
 
-#Test 1
-first_string = "download"
-first_result = replace_char_at!(first_string, "z", 0)
-p first_result == "zownload" ? "Correct" : "Incorrect"
-first_result.object_id == first_string.object_id ? "Correct" : "Incorrect"
+# check_solution runs a single test case and prints whether it was
+# successful or not.
+def check_solution(test_number, string, char, index, expected)
+    actual = replace_char_at!(string, char, index)
+    if actual != expected
+        puts "Test ##{test_number}: Incorrect value: got #{actual}, expected #{expected}"
+        return false
+    end
+    if string.object_id != actual.object_id
+        puts "Test ##{test_number}: Incorrect, must mutate original value"
+        return false
+     end
 
-#Test 2
-second_string = "account"
-second_result = replace_char_at!(second_string, "0", 3)
-p second_result == "acc0unt" ? "Correct" : "Incorrect"
-second_result.object_id == second_string.object_id ? "Correct" : "Incorrect"
+    puts "Test ##{test_number}: Correct"
+    return true
+end
 
-#Test 3
-third_string = "greatest"
-third_result = replace_char_at!(third_string, "3", 2)
-p third_result == "gr3atest" ? "Correct" : "Incorrect"
-third_result.object_id == third_string.object_id ? "Correct" : "Incorrect"
+# run_tests runs each of the test cases.
+def run_tests()
+    check_solution(1, "download", "z", 0, "zownload")
+    check_solution(2, "account", "0", 3, "acc0unt")
+    check_solution(3, "greatest", "3", 2, "gr3atest")
+end
+
+# Execute the tests.
+run_tests()

--- a/exercise_34.rb
+++ b/exercise_34.rb
@@ -14,20 +14,29 @@ end
 
 # Driver Code: Do not edit under this line
 
-#Test 1
-array_1 = [7, 0, 4]
-result_1 = scalar_multiple!(array_1, 3)
-p result_1 == [21, 0, 12] ? "Correct" : "Incorrect"
-p array_1.object_id == result_1.object_id ? "Correct" : "Incorrect"
+# check_solution runs a single test case and prints whether it was
+# successful or not.
+def check_solution(test_number, array, multiplier, expected)
+    actual = scalar_multiple!(array, multiplier)
+    if actual != expected
+        puts "Test ##{test_number}: Incorrect value: got #{actual}, expected #{expected}"
+        return false
+    end
+    if array.object_id != actual.object_id
+        puts "Test ##{test_number}: Incorrect, must mutate original value"
+        return false
+     end
 
-#Test 2
-array_2 = [90, 30, 4, 12]
-result_2 = scalar_multiple!(array_2, 0.5)
-p result_2 == [45.0, 15.0, 2.0, 6.0] ? "Correct" : "Incorrect"
-p result_2.object_id == array_2.object_id ? "Correct" : "Incorrect"
+    puts "Test ##{test_number}: Correct"
+    return true
+end
 
-#Test 3
-array_3 = [4, 48, 39, 7.2, 62.5, 12.4]
-result_3 = scalar_multiple!(array_3, 6)
-p result_3 == [24, 288, 234, 43.2, 375.0, 74.4] ? "Correct" : "Incorrect"
-p result_3.object_id == array_3.object_id ? "Correct" : "Incorrect"
+# run_tests runs each of the test cases.
+def run_tests()
+    check_solution(1, [7, 0, 4], 3, [21, 0, 12])
+    check_solution(2, [90, 30, 4, 12], 0.5, [45.0, 15.0, 2.0, 6.0])
+    check_solution(3, [4, 48, 39, 7.2, 62.5, 12.4], 6, [24, 288, 234, 43.2, 375.0, 74.4])
+end
+
+# Execute the tests.
+run_tests()

--- a/exercise_35.rb
+++ b/exercise_35.rb
@@ -18,20 +18,30 @@ end
 
 # Driver Code: Do not edit under this line
 
-#Test 1
-pets = ["Dog", "Rabbit", "Cat", "Hamster"]
-new_pets = rotate_array!(pets, 2)
-p new_pets == ["Cat", "Hamster", "Dog", "Rabbit"] ? "Correct" : "Incorrect"
-p pets.object_id == new_pets.object_id ? "Correct" : "Incorrect"
+# check_solution runs a single test case and prints whether it was
+# successful or not.
+def check_solution(test_number, steps, array, expected)
+    actual = rotate_array!(array, steps)
+    if actual != expected
+        puts "Test ##{test_number}: Incorrect value: got #{actual}, expected #{expected}"
+        return false
+    end
+    if array.object_id != actual.object_id
+        puts "Test ##{test_number}: Incorrect, must mutate original value"
+        return false
+     end
 
-#Test 2
-cities = ["NEW YORK", "TOKYO", "LONDON"]
-new_cities = rotate_array!(cities, 7)
-p new_cities == ["TOKYO", "LONDON", "NEW YORK"] ? "Correct" : "Incorrect"
-p cities.object_id == new_cities.object_id ? "Correct" : "Incorrect"
+    puts "Test ##{test_number}: Correct"
+    return true
+end
 
-#Test 3
-fruits = ["grapes", "mango", "durian", "mangosteen"]
-new_fruits = rotate_array!(fruits, -3)
-p new_fruits == ["mango", "durian", "mangosteen", "grapes"] ? "Correct" : "Incorrect"
-p fruits.object_id == new_fruits.object_id ? "Correct" : "Incorrect"
+
+# run_tests runs each of the test cases.
+def run_tests()
+    check_solution(1, 2, ["Dog", "Rabbit", "Cat", "Hamster"], ["Cat", "Hamster", "Dog", "Rabbit"])
+    check_solution(2, 7, ["NEW YORK", "TOKYO", "LONDON"], ["TOKYO", "LONDON", "NEW YORK"])
+    check_solution(3, -3, ["grapes", "mango", "durian", "mangosteen"], ["mango", "durian", "mangosteen", "grapes"])
+end
+
+# Execute the tests.
+run_tests()

--- a/exercise_36.rb
+++ b/exercise_36.rb
@@ -15,12 +15,12 @@ end
 
 #Test 1
 numbers = [4, 2, 0, 2]
-new_numbers = ele_replace!(numbers, {2=>"two", 0=>"zero", 5=>"five"})
+new_numbers = replace_elements!(numbers, {2=>"two", 0=>"zero", 5=>"five"})
 p new_numbers == [4, "two", "zero", "two"] ? "Correct" : "Incorrect"
 p numbers.object_id == new_numbers.object_id ? "Correct" : "Incorrect"
 
 #Test 2
 names = ["Matthias", "Simcha", "Mashu", "David"]
-new_names = ele_replace!(names, "Matthias"=>"J", "Mashu"=>"D")
+new_names = replace_elements!(names, "Matthias"=>"J", "Mashu"=>"D")
 p new_names == ["J", "Simcha", "D", "David"] ? "Correct" : "Incorrect"
 p names.object_id == new_names.object_id ? "Correct" : "Incorrect"

--- a/exercise_36.rb
+++ b/exercise_36.rb
@@ -13,14 +13,28 @@ end
 
 # Driver Code: Do not edit under this line
 
-#Test 1
-numbers = [4, 2, 0, 2]
-new_numbers = replace_elements!(numbers, {2=>"two", 0=>"zero", 5=>"five"})
-p new_numbers == [4, "two", "zero", "two"] ? "Correct" : "Incorrect"
-p numbers.object_id == new_numbers.object_id ? "Correct" : "Incorrect"
+# check_solution runs a single test case and prints whether it was
+# successful or not.
+def check_solution(test_number, array, hash, expected)
+    actual = replace_elements!(array, hash)
+    if actual != expected
+        puts "Test ##{test_number}: Incorrect value: got #{actual}, expected #{expected}"
+        return false
+    end
+    if array.object_id != actual.object_id
+        puts "Test ##{test_number}: Incorrect, must mutate original value"
+        return false
+     end
 
-#Test 2
-names = ["Matthias", "Simcha", "Mashu", "David"]
-new_names = replace_elements!(names, "Matthias"=>"J", "Mashu"=>"D")
-p new_names == ["J", "Simcha", "D", "David"] ? "Correct" : "Incorrect"
-p names.object_id == new_names.object_id ? "Correct" : "Incorrect"
+    puts "Test ##{test_number}: Correct"
+    return true
+end
+
+# run_tests runs each of the test cases.
+def run_tests()
+    check_solution(1, [4, 2, 0, 2], {2=>"two", 0=>"zero", 5=>"five"}, [4, "two", "zero", "two"])
+    check_solution(2, ["Matthias", "Simcha", "Mashu", "David"], {"Matthias"=>"J", "Mashu"=>"D"}, ["J", "Simcha", "D", "David"])
+end
+
+# Execute the tests.
+run_tests()


### PR DESCRIPTION
This prints more informative messages if one of the test cases fails. Here is the output if the first test case from each exercise is purposefully broken:

```bash
$ for f in *.rb; do echo "$f"; ruby $f; done
exercise_28.rb
Test #1: Incorrect value: got 50, expected 51
Test #2: Correct
Test #3: Correct
Test #4: Correct
exercise_29.rb
Test #1: Incorrect value: got true, expected false
Test #2: Correct
Test #3: Correct
Test #4: Correct
exercise_30.rb
Test #1: Incorrect value: got true, expected false
Test #2: Correct
exercise_31.rb
Test #1: Incorrect value: got ["pear", "dragonfruit", "pineapple"], expected ["pear", "dragonfruit", "fig", "pineapple"]
Test #2: Correct
Test #3: Correct
Test #4: Correct
exercise_32.rb
Test #1: Incorrect value: got 7, expected 8
Test #2: Correct
Test #3: Correct
exercise_33.rb
Test #1: Incorrect value: got zownload, expected eownload
Test #2: Correct
Test #3: Correct
exercise_34.rb
Test #1: Incorrect value: got [21, 0, 12], expected [21, 0, 13]
Test #2: Correct
Test #3: Correct
exercise_35.rb
Test #1: Incorrect value: got ["Cat", "Hamster", "Dog", "Rabbit"], expected ["Dog", "Rabbit", "Cat", "Hamster"]
Test #2: Correct
Test #3: Correct
exercise_36.rb
Test #1: Incorrect value: got [4, "two", "zero", "two"], expected [4, 2, "zero", "two"]
Test #2: Correct
```

Let me know what you think!